### PR TITLE
Export a higher-order component instead of a mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,170 @@
 ## React JSS
 
-This mixin makes [JSS](https://github.com/jsstyles/jss) easy to use from React components.
-Classes are always namespaced so use `this.sheet.classes` to access their names.
-Stylesheet is only attached until last instance is unmounted.
+Use this [higher-order component](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750) to inject [JSS](https://github.com/jsstyles/jss) stylesheets in your React components. The stylesheet is attached when there is at least one mounted component that uses it, and automatically detached when all components using it are unmounted. React JSS is compatible with live reloading using [React Hot Loader](https://github.com/gaearon/react-hot-loader).
 
-This mixin is compatible with live reloading via [React Hot Loader](https://github.com/gaearon/react-hot-loader).
 
-### Example
+React JSS wraps your React component and injects `this.props.sheet`, which is just a regular [JSS stylesheet](https://github.com/jsstyles/jss), as a prop to your component. This is a common pattern that is used for composition in React instead of mixins, and works equally well with old-style `createClass` classes, as well as the ES6 classes.
+
+Because JSS class names are namespaced by default, you will need to reach into `this.props.sheet.classes` to get their real names. For example, if you define a `button` class in your JSS stylesheet, its real name will be available as `this.props.sheet.classes.button`.
+
+### Installation
+
+```
+npm install --save react-jss
+```
+
+### Examples
+
+#### ES5
 
 ```js
-// buttonStyle.js
-module.exports = {
-  'button': {
+var React = require('react');
+var injectJSS = require('react-jss');
+
+var styles = {
+  button: {
     'background-color': 'yellow'
   },
-  'navBar': {
-    'background-color': 'red',
-    'display' : 'none'
-  },
-  'isNavOpen' : {
-    'display' : 'block'
+  label: {
+    'font-weight': 'bold'
   }
 };
 
-// Button.jsx
-var React = require('react'),
-    useSheet = require('react-jss'),
-    buttonStyle = require('./buttonStyle');
-
 var Button = React.createClass({
-  mixins: [useSheet(buttonStyle)],
+  render: function () {
+    var classes = this.props.sheet.classes;
 
-  render() {
-    // this.classSet is like React.addons.classSet, but gives you
-    // unique classes prefixed by JSS for this component's sheet
-    var containerClasses = this.classSet({
-      navBar: true,
-      isNavOpen: this.state.isOpen
-    });
-  
-    // JSS sheet is also directly available as this.sheet:
     return (
-      <div className={containerClasses}
-        <button className={this.sheet.classes.button}>
+      <div className={classes.button}>
+        <span className={classes.label}>
           {this.props.children}
-        </button>
+        </span>
       </div>
     );
   }
-});
+})
 
-module.exports = Button;
+module.exports = injectJSS(styles)(Button);
 ```
+
+#### ES6
+
+```js
+import React, { Component } from 'react';
+import injectJSS from 'react-jss';
+
+const styles = {
+  button: {
+    'background-color': 'yellow'
+  },
+  label: {
+    'font-weight': 'bold'
+  }
+};
+
+class Button extends Component {
+  render() {
+    const { classes } = this.props.sheet;
+
+    return (
+      <div className={classes.button}>
+        <span className={classes.label}>
+          {this.props.children}
+        </span>
+      </div>
+    );
+  }
+}
+
+export default injectJSS(styles)(Button);
+```
+
+#### ES7 with [decorators](https://github.com/wycats/javascript-decorators) (`{ "stage": 0 }` in [.babelrc](https://babeljs.io/docs/usage/babelrc/))
+
+```js
+import React, { Component } from 'react';
+import injectJSS from 'react-jss';
+
+const styles = {
+  button: {
+    'background-color': 'yellow'
+  },
+  label: {
+    'font-weight': 'bold'
+  }
+};
+
+@injectJSS(styles)
+export default class Button extends Component {
+  render() {
+    const { classes } = this.props.sheet;
+
+    return (
+      <div className={classes.button}>
+        <span className={classes.label}>
+          {this.props.children}
+        </span>
+      </div>
+    );
+  }
+};
+```
+
+### Do you have a `classSet` helper?
+
+We used to support a `classSet` helper in 0.x, but React is removing `React.addons.classSet` soon, and so are we. There are many alternative userland solutions, such as Jed Watson's excellent [classnames](https://github.com/JedWatson/classnames) library, so we suggest you use it instead.
+
+It's easy to use with generated class names. If you're writing in ES6, you can use computed property names in the object literal:
+
+```js
+import classSet from 'classnames';
+
+  // ...
+
+  render() {
+    const { classes } = this.props.sheet;
+    return (
+      <div className={classSet({
+        [classes.normal]: true,
+        [classes.active]: this.state.active
+      })}>
+        {this.props.children}
+      </div>
+    );
+  );
+```
+
+If you're still writing in ES5 ([you should consider Babel though!](https://babeljs.io/)), you can just supply an array:
+
+```js
+ var classSet = require('classnames');
+
+  // ...
+
+ render: function () {
+    var classes = this.props.sheet.classes;
+    return (
+      <div className={classNames(
+        classes.normal,
+        this.state.active && classes.active
+      )}>
+        {this.props.children}
+      </div>
+    );
+  }
+```
+
+Either way, you can see now that there is no real need for a dedicated `classSet` helper in this project.
+
+### API
+
+React JSS exports a function that, when invoked with `rules` and `options`, will return another function. That second function takes a `ReactClass` and wraps it, returning the wrapper `ReactClass`. Both `rules` and `options` are passed as arguments to `jss.createStyleSheet` call internally.
+
+```
+injectJSS: (rules, [, options]) => (ReactClass) => ReactClass
+```
+
+This partial application matches the signature for [ES7 decorators](https://github.com/wycats/javascript-decorators).
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 ## React JSS
 
-Use this [higher-order component](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750) to inject [JSS](https://github.com/jsstyles/jss) stylesheets into your React components. It can act both as a simple wrapping function and as an [ES7 decorator](https://github.com/wycats/javascript-decorators). The stylesheet is attached when there is at least one mounted component that uses it, and automatically detached when all components using it are unmounted. React JSS is compatible with live reloading using [React Hot Loader](https://github.com/gaearon/react-hot-loader).
+Use this [higher-order component](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750) to inject [JSS](https://github.com/jsstyles/jss) stylesheets into your React components. It can act both as a simple wrapping function and as an [ES7 decorator](https://github.com/wycats/javascript-decorators).
 
 React JSS wraps your React component and injects `this.props.sheet`, which is just a regular [JSS stylesheet](https://github.com/jsstyles/jss), as a prop into your component. This is a common pattern that is used for composition in React instead of mixins, and works equally well with old-style `createClass` classes, as well as the ES6 classes.
+
+The stylesheet is attached when there is at least one mounted component that uses it, and automatically detached when all components using it are unmounted. React JSS is compatible with live reloading using [React Hot Loader](https://github.com/gaearon/react-hot-loader).
 
 Because JSS class names are namespaced by default, you will need to reach into `this.props.sheet.classes` to get their real names. For example, if you define a `button` class in your JSS stylesheet, its real name will be available as `this.props.sheet.classes.button`.
 
@@ -158,7 +160,7 @@ Either way, you can see now that there is no real need for a dedicated `classSet
 ### API
 
 React JSS has two overloads.
-If you're using ES5 or ES6, use this overload:
+If you are using ES5 or ES6, use this overload:
 
 ```js
 // ES5 and ES6
@@ -167,7 +169,7 @@ useSheet: (ReactClass, rules[, options]) => ReactClass
 
 It lets you pass your React component class as the first parameter.
 
-There is also another signature designed specifically to be used with [ES7 decorators](https://github.com/wycats/javascript-decorators). It activates if you are passing the styles as the first parameter instead of the component:
+There is also another signature designed specifically to be used with [ES7 decorators](https://github.com/wycats/javascript-decorators). It activates if pass the styles as the first parameter instead of the component:
 
 ```js
 // ES7
@@ -176,7 +178,8 @@ useSheet: (rules, [, options]) => (ReactClass) => ReactClass
 
 This overload returns a partial function, to which you then should pass your React component class. This is only useful because [ES7 decorators](https://github.com/wycats/javascript-decorators) expect such signature. If you use ES5 or ES6, just ignore it and use the first overload instead.
 
-In both overloads, `rules` and `options` are the arguments to the `jss.createStyleSheet` call inside.
+In both overloads, `rules` and `options` are the arguments to the `jss.createStyleSheet` call inside.  
+If you're not sure which overload to use, go with the first one.
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 ## React JSS
 
-Use this [higher-order component](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750) to inject [JSS](https://github.com/jsstyles/jss) stylesheets in your React components. The stylesheet is attached when there is at least one mounted component that uses it, and automatically detached when all components using it are unmounted. React JSS is compatible with live reloading using [React Hot Loader](https://github.com/gaearon/react-hot-loader).
+Use this [higher-order component](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750) to inject [JSS](https://github.com/jsstyles/jss) stylesheets into your React components. The stylesheet is attached when there is at least one mounted component that uses it, and automatically detached when all components using it are unmounted. React JSS is compatible with live reloading using [React Hot Loader](https://github.com/gaearon/react-hot-loader).
 
-
-React JSS wraps your React component and injects `this.props.sheet`, which is just a regular [JSS stylesheet](https://github.com/jsstyles/jss), as a prop to your component. This is a common pattern that is used for composition in React instead of mixins, and works equally well with old-style `createClass` classes, as well as the ES6 classes.
+React JSS wraps your React component and injects `this.props.sheet`, which is just a regular [JSS stylesheet](https://github.com/jsstyles/jss), as a prop into your component. This is a common pattern that is used for composition in React instead of mixins, and works equally well with old-style `createClass` classes, as well as the ES6 classes.
 
 Because JSS class names are namespaced by default, you will need to reach into `this.props.sheet.classes` to get their real names. For example, if you define a `button` class in your JSS stylesheet, its real name will be available as `this.props.sheet.classes.button`.
 
@@ -144,7 +143,7 @@ If you're still writing in ES5 ([you should consider Babel though!](https://babe
  render: function () {
     var classes = this.props.sheet.classes;
     return (
-      <div className={classNames(
+      <div className={classSet(
         classes.normal,
         this.state.active && classes.active
       )}>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## React JSS
 
-Use this [higher-order component](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750) to inject [JSS](https://github.com/jsstyles/jss) stylesheets into your React components. The stylesheet is attached when there is at least one mounted component that uses it, and automatically detached when all components using it are unmounted. React JSS is compatible with live reloading using [React Hot Loader](https://github.com/gaearon/react-hot-loader).
+Use this [higher-order component](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750) to inject [JSS](https://github.com/jsstyles/jss) stylesheets into your React components. It can act both as a simple wrapping function and as an [ES7 decorator](https://github.com/wycats/javascript-decorators). The stylesheet is attached when there is at least one mounted component that uses it, and automatically detached when all components using it are unmounted. React JSS is compatible with live reloading using [React Hot Loader](https://github.com/gaearon/react-hot-loader).
 
 React JSS wraps your React component and injects `this.props.sheet`, which is just a regular [JSS stylesheet](https://github.com/jsstyles/jss), as a prop into your component. This is a common pattern that is used for composition in React instead of mixins, and works equally well with old-style `createClass` classes, as well as the ES6 classes.
 
@@ -18,7 +18,7 @@ npm install --save react-jss
 
 ```js
 var React = require('react');
-var injectJSS = require('react-jss');
+var useSheet = require('react-jss');
 
 var styles = {
   button: {
@@ -43,14 +43,14 @@ var Button = React.createClass({
   }
 })
 
-module.exports = injectJSS(styles)(Button);
+module.exports = useSheet(Button, styles);
 ```
 
 #### ES6
 
 ```js
 import React, { Component } from 'react';
-import injectJSS from 'react-jss';
+import useSheet from 'react-jss';
 
 const styles = {
   button: {
@@ -75,14 +75,14 @@ class Button extends Component {
   }
 }
 
-export default injectJSS(styles)(Button);
+export default useSheet(Button, styles);
 ```
 
 #### ES7 with [decorators](https://github.com/wycats/javascript-decorators) (`{ "stage": 0 }` in [.babelrc](https://babeljs.io/docs/usage/babelrc/))
 
 ```js
 import React, { Component } from 'react';
-import injectJSS from 'react-jss';
+import useSheet from 'react-jss';
 
 const styles = {
   button: {
@@ -93,7 +93,7 @@ const styles = {
   }
 };
 
-@injectJSS(styles)
+@useSheet(styles)
 export default class Button extends Component {
   render() {
     const { classes } = this.props.sheet;
@@ -157,13 +157,26 @@ Either way, you can see now that there is no real need for a dedicated `classSet
 
 ### API
 
-React JSS exports a function that, when invoked with `rules` and `options`, will return another function. That second function takes a `ReactClass` and wraps it, returning the wrapper `ReactClass`. Both `rules` and `options` are passed as arguments to `jss.createStyleSheet` call internally.
+React JSS has two overloads.
+If you're using ES5 or ES6, use this overload:
 
-```
-injectJSS: (rules, [, options]) => (ReactClass) => ReactClass
+```js
+// ES5 and ES6
+useSheet: (ReactClass, rules[, options]) => ReactClass
 ```
 
-This partial application matches the signature for [ES7 decorators](https://github.com/wycats/javascript-decorators).
+It lets you pass your React component class as the first parameter.
+
+There is also another signature designed specifically to be used with [ES7 decorators](https://github.com/wycats/javascript-decorators). It activates if you are passing the styles as the first parameter instead of the component:
+
+```js
+// ES7
+useSheet: (rules, [, options]) => (ReactClass) => ReactClass
+```
+
+This overload returns a partial function, to which you then should pass your React component class. This is only useful because [ES7 decorators](https://github.com/wycats/javascript-decorators) expect such signature. If you use ES5 or ES6, just ignore it and use the first overload instead.
+
+In both overloads, `rules` and `options` are the arguments to the `jss.createStyleSheet` call inside.
 
 ### License
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/jsstyles/react-jss",
   "peerDependencies": {
     "jss": "^1.0.0",
-    "react": ">=0.12"
+    "react": ">=0.13"
   },
   "devDependencies": {
     "babel": "^5.2.17"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jss",
-  "version": "0.1.3",
+  "version": "1.0.0",
   "description": "JSS mixin for React components",
   "main": "modules/index.js",
   "scripts": {
@@ -17,7 +17,8 @@
     "css",
     "stylesheet",
     "jss",
-    "mixin"
+    "hoc",
+    "decorator"
   ],
   "author": "Dan Abramov <dan.abramov@me.com> (http://github.com/gaearon)",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import jss from 'jss';
 
-export default function injectSheet(rules, options) {
+function decorate(DecoratedComponent, rules, options) {
   let refs = 0;
   let sheet = null;
 
@@ -31,41 +31,46 @@ export default function injectSheet(rules, options) {
       detach();
   }
 
-  return function wrap(DecoratedComponent) {
-    const displayName =
-      DecoratedComponent.displayName ||
-      DecoratedComponent.name ||
-      'Component';
+  const displayName =
+    DecoratedComponent.displayName ||
+    DecoratedComponent.name ||
+    'Component';
 
-    return class StyleSheetWrapper {
-      static wrapped = DecoratedComponent;
-      static displayName = `JSS(${displayName})`;
+  return class StyleSheetWrapper {
+    static wrapped = DecoratedComponent;
+    static displayName = `JSS(${displayName})`;
 
-      componentWillMount() {
-        this.sheet = ref();
-      }
+    componentWillMount() {
+      this.sheet = ref();
+    }
 
-      componentWillUpdate() {
-        if (process.env.NODE_ENV !== 'production') {
-          // Support React Hot Loader
-          if (this.sheet !== sheet) {
-            this.sheet.detach();
-            this.sheet = ref();
-          }
+    componentWillUpdate() {
+      if (process.env.NODE_ENV !== 'production') {
+        // Support React Hot Loader
+        if (this.sheet !== sheet) {
+          this.sheet.detach();
+          this.sheet = ref();
         }
       }
+    }
 
-      componentWillUnmount() {
-        deref();
-        this.sheet = null;
-      }
+    componentWillUnmount() {
+      deref();
+      this.sheet = null;
+    }
 
-      render() {
-        return (
-          <DecoratedComponent {...this.props}
-                              sheet={this.sheet} />
-        );
-      }
+    render() {
+      return (
+        <DecoratedComponent {...this.props} sheet={this.sheet} />
+      );
     }
   };
+}
+
+export default function useSheet(rulesOrComponent) {
+  if (typeof rulesOrComponent === 'function') {
+    return decorate(...arguments);
+  }
+
+  return (DecoratedComponent) => decorate(DecoratedComponent, ...arguments);
 }


### PR DESCRIPTION
This is my take on a HOC. I tried to go with #11 but there were a number of things I wanted to differently so I went with a separate PR. (Still, thanks to @timbur for the effort, it helped me to see what I'd like to be changed :+1: )

This is what's different

* I'd like to avoid exporting both mixin and HOC. We're bumping the major version so it's not a big deal to stop supporting the mixin. People using `React.createClass` can still use the HOC—it will work for everyone so it's a better solution.

* I saw no reason for keeping `sheet` in the `state` so I keep it in an instance field instead, just like before.

* I'm removing `classSet` helper. I don't think it's appropriate now that React is going to deprecate their own `classSet` helper. There are microlibraries like [classnames](https://github.com/JedWatson/classnames) that do a better job on this, and we should just tell people to use them.

I'm going to update the PR with docs and release this later today.
Thanks again, @timbur and @kof.