### PR TITLE
Added a ref value to the DecoratedComponent

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ function decorate(DecoratedComponent, rules, options = {}) {
 
     render() {
       return (
-        <DecoratedComponent {...this.props} sheet={this.sheet} />
+        <DecoratedComponent ref="wrapped" {...this.props} sheet={this.sheet} />
       );
     }
   };


### PR DESCRIPTION
React-Jss has moved from a mixin system to a higher-order component system. Within it, the real component is wrapped in another component that contains jss-specific functionality and then exposes the new functionality in the form of an injected prop called 'sheet'. This normally works because the react-jss wrapping component (hereunto called 'StyleSheetWrapper') propagates the props forward into the real component in its render method.

However, there is another form of inter-component communication that is relatively rare, but important called [Exposed Component Functions](https://facebook.github.io/react/tips/expose-component-functions.html). Using a ref to a child component, a parent component may directly call a method on the child component. This wouldn't be used to transfer data, but it would be used to trigger actions on the child from the parent not reasonably expressed with data, such as "You've just become 'active,' focus the cursor to your appropriate input field."

By merging this pull request, a parent component can use the following code to call a function on a child component that has been wrapped by react-jss (and only react-jss).
`this.refs.WRAPPED_COMPONENT.refs.wrapped.CHILD_METHOD()`
as opposed to the following when using mixins
`this.refs.CHILD_COMPONENT.CHILD_METHOD()`

This solution leaves a lot to be desired, though these issues are not specific to react-jss, but to higher-order component usage by React in general.

First, StyleSheetWrapper might be wrapping another wrapped component, or it might be wrapped itself. There is no way for StyleSheetWrapper to know where the original component is, nor any other wrapping higher-order component in the chain. Furthermore, other wrapping components might not wrap just one component, but may instead create meaningful refs that are not the original component.

Second, while replacing mixins with higher-order components removes the potential for multiple inheritance collisions, now the parent must have knowledge that the child is wrapped, in what order it is wrapped, and what refs those wrappers create.