### PR TITLE
Extend wrapper class with React.Component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ function decorate(DecoratedComponent, rules, options = {}) {
     DecoratedComponent.name ||
     'Component';
 
-  return class StyleSheetWrapper {
+  return class StyleSheetWrapper extends React.Component {
     static wrapped = DecoratedComponent;
     static displayName = `JSS(${displayName})`;
 


### PR DESCRIPTION
stateless components in React v0.14.0 require components to extend React.Component.