### PR TITLE
Fixed mention of babel stage for decorators by the babel-plugin-transform-decorators-legacy plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ class Button extends Component {
 export default useSheet(Button, styles)
 ```
 
-#### ES7 with [decorators](https://github.com/wycats/javascript-decorators) (`{ "presets": ["stage-1"] }` in [.babelrc](https://babeljs.io/docs/usage/babelrc/))
+#### ES7 with [decorators](https://github.com/wycats/javascript-decorators) (using [babel-plugin-transform-decorators-legacy](https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy))
 
 ```javascript
 import React, { Component } from 'react'


### PR DESCRIPTION
Hi,

Babel doesn't support decorators anymore: 
- http://babeljs.io/docs/plugins/transform-decorators/
- http://babeljs.io/docs/plugins/preset-stage-1/

So you need to install https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy to use decorators now.

I'm just fixing the readme.